### PR TITLE
Add headers

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -6,6 +6,7 @@ export class Request {
   public body: string;
   public cookies: any;
   public fresh: boolean;
+  public headers: any;
   public hostname: string;
   public ip: string;
   public ips: string[];
@@ -36,6 +37,7 @@ export class Request {
     this.body = '';
     this.cookies = {};
     this.fresh = false;
+    this.headers = {};
     this.hostname = '';
     this.ip = '';
     this.ips = [];
@@ -68,6 +70,7 @@ export class Request {
     this.body = '';
     this.cookies = {};
     this.fresh = false;
+    this.headers = {};
     this.hostname = '';
     this.ip = '';
     this.ips = [];
@@ -107,6 +110,10 @@ export class Request {
 
   public setFresh(value: boolean) {
     this.fresh = value;
+  }
+
+  public setHeaders(key: string, value: string) {
+    this.headers[key] = value;
   }
 
   public setIp(value: string) {

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -115,6 +115,35 @@ describe('Express Request', () => {
     });
   });
 
+  describe('Test headers', () => {
+    test('headers should be empty by default', () => {
+      expect(request.headers).toEqual({});
+    });
+
+    test('headers should allow you to update it', () => {
+      const firstKey = chance.string({ pool: 'abcdefghijklmnopqrstuvwxyz' });
+      const firstValue = chance.string();
+      const secondKey = chance.string({ pool: 'abcdefghijklmnopqrstuvwxyz' });
+      const secondValue = chance.string();
+      request.setHeaders(firstKey, firstValue);
+      expect(request.headers).toHaveProperty(firstKey, firstValue);
+
+      request.setHeaders(secondKey, secondValue);
+      expect(request.headers).toHaveProperty(firstKey, firstValue);
+      expect(request.headers).toHaveProperty(secondKey, secondValue);
+    });
+
+    test('params should be empty after reset', () => {
+      const key = chance.string({ pool: 'abcdefghijklmnopqrstuvwxyz' });
+      const value = chance.string();
+      request.setHeaders(key, value);
+
+      request.resetMocked();
+
+      expect(request.headers).toEqual({});
+    });
+  });
+
   describe('Test ip', () => {
     test('ip should be VALUE by default', () => {
       expect(request.ip).toEqual('');

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -337,7 +337,6 @@ describe('Express Request', () => {
       request.setQuery(firstKey, firstValue);
       expect(request.query).toHaveProperty(firstKey, firstValue);
 
-
       const secondKey = chance.string({ pool: 'abcdefghijklmnopqrstuvwxyz' });
       const secondValue = chance.string();
       request.setQuery(secondKey, secondValue);


### PR DESCRIPTION
**What**: Closes https://github.com/jameswlane/jest-express/issues/4. This library is missing the ability to get/set headers.

**Why**: Headers are important?

**How**: Mostly by copying how `params`, another key/value argument, was implemented.

By the way, as I was adding this code to the README, I noticed something odd. It seems that quite a lot of the README table of contents and samples are broken. For example, `setParams()`, linked under `Request`, links to `#requestsetparams` and doesn't go anywhere. And `params`, linked under `Request`, links to `#requestbaseUrl` which also doesn't go anywhere. But in fact, none of the getters look correct: `path`, linked under `Request`, does go `#requestpath`, but this only shows how to make use of `setRequestPath()` (all the getters seem to link to setter examples). For this reason, I didn't add docs for this API. 