### PR TITLE
Reduce noise, ignore some greenkeeper dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,18 @@
     "tslint-config-airbnb": "5.10.0",
     "typescript": "3.0.1"
   },
+  "greenkeeper": {
+    "ignore": [
+      "@commitlint/cli",
+      "@commitlint/config-conventional",
+      "@types/faker",
+      "@types/chance",
+      "tslint-config-airbnb",
+      "faker",
+      "chance",
+      "codecov"
+    ]
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
It seems you're not merging some greenkeeper updates, I think it's not without reason, they are very low priority. I add them to ignore list to reduce noise