### PR TITLE
Make res.send chainable

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -58,7 +58,7 @@ export class Response {
     this.location = jest.fn(() => this);
     this.redirect = jest.fn();
     this.render = jest.fn();
-    this.send = jest.fn();
+    this.send = jest.fn(() => this);
     this.sendFile = jest.fn();
     this.sendStatus = jest.fn();
     this.set = jest.fn((key: string | { [key: string]: string }, value: string | void) => {

--- a/test/unit/response.test.ts
+++ b/test/unit/response.test.ts
@@ -606,6 +606,12 @@ describe('Express Response', () => {
       response.resetMocked();
       expect(response.send).not.toHaveBeenCalled();
     });
+
+    test('send returns response so is chainable', () => {
+      const value = chance.string();
+      expect(response.send(value)).toBe(response);
+    });
+
   });
 
   describe('Test sendFile', () => {


### PR DESCRIPTION
**What**:

Make `res.send()` match [the express implementation](https://github.com/expressjs/express/blob/dc538f6e810bd462c98ee7e6aae24c64d4b1da93/lib/response.js#L224), which is chainable.

<!-- Why are these changes necessary? -->
**Why**:

To achieve parity with real express

<!-- How were these changes implemented? -->
**How**:

Return `this` from the mocked `send` function.


Thanks for a great project!
