### PR TITLE
feat(req.app): adds functionality documented in express to access app…

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -41,7 +41,7 @@ export class Express {
   private setting: any;
 
   constructor() {
-    this.request = new Request();
+    this.request = new Request(null, { app: this });
     this.response = new Response();
     this.next = next;
     // Properties

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,8 +1,10 @@
 import { parse } from 'url';
+import { Express } from './express';
 
 interface IRequestOptions {
   method?: 'GET' | 'POST' | 'DELETE' | 'PATCH' | 'PUT' | 'HEAD' | 'OPTIONS' | 'CONNECT';
   headers?: any;
+  app: Express;
 }
 
 declare const jest: any;
@@ -37,11 +39,13 @@ export class Request {
   public get: any;
   public is: any;
   public range: any;
+  // Application
+  public app: Express;
 
   private defaultUrl: string | undefined;
   private defaultOptions: IRequestOptions | undefined;
 
-  constructor(url?: string, options?: IRequestOptions) {
+  constructor(url?: string|null, options?: IRequestOptions) {
     // Properties
     this.baseUrl = '';
     this.body = '';
@@ -71,6 +75,8 @@ export class Request {
     this.get = jest.fn().mockImplementation((header: string) => this.headers[header]);
     this.is = jest.fn();
     this.range = jest.fn();
+    // Application
+    this.app = (options && options.app) ? options.app : new Express();
 
     if (typeof url === 'string') {
       this.defaultUrl = url;

--- a/test/unit/express.test.ts
+++ b/test/unit/express.test.ts
@@ -583,10 +583,17 @@ describe('Express Application', () => {
     app.get('/', [testMiddleware, testMiddleware], testMiddleware);
   });
 
-  test('Get Settings', () => {
-    app.set('title', 'My Site');
-    const title = app.get('title');
-    expect(title).toMatch('My Site');
+  describe('Test set', () => {
+    test('should set and get settings', () => {
+      app.set('title', 'My Site');
+      const title = app.get('title');
+      expect(title).toMatch('My Site');
+    });
+    test('should set on request application object', () => {
+      app.set('title', 'My Site');
+      const title = app.request.app.get('title');
+      expect(title).toMatch('My Site');
+    });
   });
 
   describe('Route', () => {

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -1,5 +1,6 @@
 import * as Chance from 'chance';
 
+import { Express } from '../../src/express';
 import { Request } from '../../src/request';
 
 const chance = new Chance();
@@ -57,6 +58,12 @@ describe('Express Request', () => {
         method: 'POST',
       });
       expect(request.method).toEqual('POST');
+    });
+
+    test('request should allow to set application', () => {
+      const app = new Express();
+      app.set('title', 'value');
+      expect(new Request(null, { app }).app.get('title')).toEqual('value');
     });
 
     test('request should reset to initial values upon resetMocked', () => {


### PR DESCRIPTION
… on request object

When an Express class is created it now passes a reference to the Request object created in its
constructor which handles expected behaviour when req.app is referenced. When a Request class is
created an option can be given (options.app) to pass an application object to use.

fix #183

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
adds functionality documented in express to access application on request object (req.app)

<!-- Why are these changes necessary? -->
**Why**:
Using functionality described in the Express.js documentation would lead to TypesErrors in Jest when calls to req.app.get are used because req.app would be undefined.

<!-- How were these changes implemented? -->
**How**:
When an Express class is created it now passes a reference to the Request object created in its
constructor which handles expected behaviour when req.app is referenced. When a Request class is
created an option can be given (options.app) to pass an application object to use.

I'm still getting back to grips with Typescript so if you prefer destructing in some pattern I've yet to remember please let me know!
