### PR TITLE
feat(Response): add 'responseHeader' method

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -120,6 +120,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "benbakhar",
+      "name": "Ben Bakhar",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/7517258?v=4",
+      "profile": "https://github.com/benbakhar",
+      "contributions": [
+        "code",
+        "test",
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Mock Express for testing with Jest
     * [type()](#responsetype)
     * [vary()](#responsevary)
     * [setHeader()](#responsesetheader)
+    * [removeHeader()](#responseremoveHeader)
     * [setHeadersSent()](#responsesetheaderssent)
     * [setLocals()](#responsesetlocals)
     * [resetMocked()](#resetmocked)
@@ -741,6 +742,19 @@ beforeEach(() => {
 });
 ```
 
+#### `response.removeHeader`
+
+Ways to use this API:
+
+Setup:
+```js
+beforeEach(() => {
+  response = new Response();
+  response.removeHeader(key);
+  expect(response.removeHeader).toBeCalledWith(key);
+});
+```
+
 #### `response.headersSent`
 
 Ways to use this API:
@@ -1073,6 +1087,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://www.maxholman.com"><img src="https://avatars3.githubusercontent.com/u/250517?v=4" width="100px;" alt=""/><br /><sub><b>Max Holman</b></sub></a><br /><a href="https://github.com/jameswlane/jest-express/commits?author=maxholman" title="Code">💻</a> <a href="https://github.com/jameswlane/jest-express/commits?author=maxholman" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/mnalsup"><img src="https://avatars3.githubusercontent.com/u/5252756?v=4" width="100px;" alt=""/><br /><sub><b>Matthew Alsup</b></sub></a><br /><a href="https://github.com/jameswlane/jest-express/commits?author=mnalsup" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/ttxndrx"><img src="https://avatars3.githubusercontent.com/u/6355781?v=4" width="100px;" alt=""/><br /><sub><b>ttxndrx</b></sub></a><br /><a href="https://github.com/jameswlane/jest-express/commits?author=ttxndrx" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/benbakhar"><img src="https://avatars1.githubusercontent.com/u/7517258?v=4" width="100px;" alt=""/><br /><sub><b>Ben Bakhar</b></sub></a><br /><a href="https://github.com/jameswlane/jest-express/commits?author=benbakhar" title="Code">💻</a> <a href="https://github.com/jameswlane/jest-express/commits?author=benbakhar" title="Tests">⚠️</a> <a href="https://github.com/jameswlane/jest-express/commits?author=benbakhar" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/chance": "1.0.8",
     "@types/faker": "4.1.9",
     "@types/jest": "24.0.25",
-    "@types/node": "12.12.21",
+    "@types/node": "13.1.6",
     "all-contributors-cli": "6.12.0",
     "babel-core": "6.26.3",
     "babel-jest": "24.9.0",

--- a/src/response.ts
+++ b/src/response.ts
@@ -29,6 +29,7 @@ export class Response {
   public status: any;
   public type: any;
   public vary: any;
+  public removeHeader: any;
 
   constructor() {
     // Properties
@@ -78,6 +79,8 @@ export class Response {
     this.status = jest.fn(() => this);
     this.type = jest.fn(() => this);
     this.vary = jest.fn(() => this);
+    this.removeHeader = jest.fn(() => this);
+
     return this;
   }
 
@@ -122,5 +125,6 @@ export class Response {
     this.status.mockReset();
     this.type.mockReset();
     this.vary.mockReset();
+    this.removeHeader.mockReset();
   }
 }

--- a/test/unit/response.test.ts
+++ b/test/unit/response.test.ts
@@ -794,4 +794,31 @@ describe('Express Response', () => {
       expect(response.vary(value)).toBe(response);
     });
   });
+
+  describe('Test removeHeader', () => {
+    test('removeHeader should have no calls by default', () => {
+      expect(response.removeHeader).not.toHaveBeenCalled();
+    });
+
+    test('removeHeader should be called and match called with', () => {
+      const value = chance.string();
+      response.removeHeader(value);
+
+      expect(response.removeHeader).toHaveBeenCalled();
+      expect(response.removeHeader).toHaveBeenCalledWith(value);
+    });
+
+    test('removeHeader should have no call after reset', () => {
+      const value = chance.string();
+      response.removeHeader(value);
+
+      response.resetMocked();
+      expect(response.removeHeader).not.toHaveBeenCalled();
+    });
+
+    test('removeHeader returns response so is chainable', () => {
+      const value = chance.string();
+      expect(response.removeHeader(value)).toBe(response);
+    });
+  });
 });


### PR DESCRIPTION
**What**: Extend `Response` class with `removeHeader` method.

**Why**: To be compatible with express's Response API.

**How**: Extending the `Response` class with a new public method.

Fixes #392 