### PR TITLE
set the response.body when using response write methods

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -56,8 +56,14 @@ export class Response {
       }
       return this;
     });
-    this.json = jest.fn();
-    this.jsonp = jest.fn();
+    this.json = jest.fn((data : any) => {
+      this.body = data;
+      return this;
+    });
+    this.jsonp = jest.fn((data : any) => {
+      this.body = data;
+      return this;
+    });
     this.links = jest.fn(() => this);
     this.location = jest.fn(() => this);
     this.redirect = jest.fn();

--- a/src/response.ts
+++ b/src/response.ts
@@ -30,6 +30,7 @@ export class Response {
   public setHeader: any;
   public status: any;
   public type: any;
+  public text: any;
   public vary: any;
   public removeHeader: any;
 
@@ -38,6 +39,7 @@ export class Response {
     this.headers = {};
     this.headersSent = false;
     this.locals = {};
+    this.body = {};
     this.statusCode = 200;
     // Methods
     this.append = jest.fn(() => this);
@@ -93,6 +95,10 @@ export class Response {
       return this;
     });
     this.type = jest.fn(() => this);
+    this.text = jest.fn((data: any) => {
+      this.body = data;
+      return this;
+    });
     this.vary = jest.fn(() => this);
     this.removeHeader = jest.fn(() => this);
 
@@ -120,6 +126,7 @@ export class Response {
     this.append.mockReset();
     this.attachment.mockReset();
     this.cookie.mockReset();
+    this.body = {};
     this.clearCookie.mockReset();
     this.download.mockReset();
     this.end.mockReset();
@@ -138,6 +145,7 @@ export class Response {
     this.set.mockReset();
     this.setHeader.mockReset();
     this.status.mockReset();
+    this.text.mockReset();
     this.type.mockReset();
     this.vary.mockReset();
     this.removeHeader.mockReset();

--- a/test/unit/response.test.ts
+++ b/test/unit/response.test.ts
@@ -456,6 +456,7 @@ describe('Express Response', () => {
 
       expect(response.json).toHaveBeenCalled();
       expect(response.json).toHaveBeenCalledWith(value);
+      expect(response.body).toEqual(value);
     });
 
     test('json should have no call after reset', () => {
@@ -478,6 +479,7 @@ describe('Express Response', () => {
 
       expect(response.jsonp).toHaveBeenCalled();
       expect(response.jsonp).toHaveBeenCalledWith(value);
+      expect(response.body).toEqual(value);
     });
 
     test('jsonp should have no call after reset', () => {

--- a/test/unit/response.test.ts
+++ b/test/unit/response.test.ts
@@ -592,6 +592,7 @@ describe('Express Response', () => {
   describe('Test send', () => {
     test('send should have no calls by default', () => {
       expect(response.send).not.toHaveBeenCalled();
+      expect(response.body).toEqual({})
     });
 
     test('send should be called and match called with', () => {
@@ -609,6 +610,7 @@ describe('Express Response', () => {
 
       response.resetMocked();
       expect(response.send).not.toHaveBeenCalled();
+      expect(response.body).toEqual({})
     });
 
     test('send returns response so is chainable', () => {
@@ -661,6 +663,7 @@ describe('Express Response', () => {
 
       response.resetMocked();
       expect(response.sendStatus).not.toHaveBeenCalled();
+      expect(response.body).toEqual({})
     });
   });
 
@@ -783,6 +786,37 @@ describe('Express Response', () => {
       expect(response.type(value)).toBe(response);
     });
   });
+
+  describe('Test text', () => {
+    test('text should have no calls by default', () => {
+      expect(response.text).not.toHaveBeenCalled();
+    })
+
+    test('text should be called and match called with', () => {
+      const value = chance.string();
+      response.text(value);
+
+      expect(response.text).toHaveBeenCalled();
+      expect(response.text).toHaveBeenCalledWith(value);
+      expect(response.body).toEqual(value);
+    });
+
+    test('text should have no call after reset', () => {
+      const value = chance.string();
+      response.text(value);
+
+      response.resetMocked();
+      expect(response.text).not.toHaveBeenCalled();
+      expect(response.body).toEqual({});
+    });
+
+    test('text returns response so is chainable', () => {
+      const value = chance.string();
+      expect(response.text(value)).toBe(response);
+    });
+  });
+
+  
 
   describe('Test vary', () => {
     test('vary should have no calls by default', () => {

--- a/test/unit/response.test.ts
+++ b/test/unit/response.test.ts
@@ -592,7 +592,7 @@ describe('Express Response', () => {
   describe('Test send', () => {
     test('send should have no calls by default', () => {
       expect(response.send).not.toHaveBeenCalled();
-      expect(response.body).toEqual({})
+      expect(response.body).toEqual({});
     });
 
     test('send should be called and match called with', () => {
@@ -610,7 +610,7 @@ describe('Express Response', () => {
 
       response.resetMocked();
       expect(response.send).not.toHaveBeenCalled();
-      expect(response.body).toEqual({})
+      expect(response.body).toEqual({});
     });
 
     test('send returns response so is chainable', () => {
@@ -663,7 +663,7 @@ describe('Express Response', () => {
 
       response.resetMocked();
       expect(response.sendStatus).not.toHaveBeenCalled();
-      expect(response.body).toEqual({})
+      expect(response.body).toEqual({});
     });
   });
 
@@ -790,7 +790,7 @@ describe('Express Response', () => {
   describe('Test text', () => {
     test('text should have no calls by default', () => {
       expect(response.text).not.toHaveBeenCalled();
-    })
+    });
 
     test('text should be called and match called with', () => {
       const value = chance.string();
@@ -815,8 +815,6 @@ describe('Express Response', () => {
       expect(response.text(value)).toBe(response);
     });
   });
-
-  
 
   describe('Test vary', () => {
     test('vary should have no calls by default', () => {


### PR DESCRIPTION
set the `reponse.body` when using `response.json()`, `response.jsonp()`, `response.text()`