### PR TITLE
Add tests for #414 and alias req.get as req.header

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -45,6 +45,7 @@ export class Request {
   public acceptsEncodings: any;
   public acceptsLanguages: any;
   public get: any;
+  public header: any;
   public is: any;
   public range: any;
   // Application
@@ -80,7 +81,7 @@ export class Request {
     this.acceptsCharsets = jest.fn();
     this.acceptsEncodings = jest.fn();
     this.acceptsLanguages = jest.fn();
-    this.get = jest
+    this.get = this.header = jest
       .fn()
       .mockImplementation((header: string) => this.headers[header.toLowerCase()]);
     this.is = jest.fn();

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -922,6 +922,28 @@ describe('Express Request', () => {
 
       expect(request.get(key)).toEqual(value);
     });
+
+    test('should return header value when key is uppercase', () => {
+      const key = chance.string({ pool: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' });
+      const value = chance.string();
+
+      request.setHeaders(key, value);
+
+      expect(request.get(key)).toEqual(value);
+    });
+
+    test('should return header value when case differs', () => {
+      const key = chance.string({ pool: 'abcdefghijklmnopqrstuvwxyz' });
+      const value = chance.string();
+
+      request.setHeaders(key.slice(0, 1).toUpperCase() + key.slice(1), value);
+
+      expect(request.get(key.slice(0, 2).toUpperCase() + key.slice(2))).toEqual(value);
+    });
+
+    test('should be aliased as header', () => {
+      expect(request.get).toBe(request.header);
+    });
   });
 
   describe('Test is', () => {


### PR DESCRIPTION
**What**:
Added tests for #414 - `.get()` should work regardless of the casing of the argument.
Aliased req.get() as req.header().

**Why**:
Tests are good.
req.get() is aliased as request.header() in the actual request object: https://expressjs.com/en/api.html#req.get
