### PR TITLE
response.redirect() to set 'Location' header

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "lint-staged": "10.1.3",
     "opt-cli": "1.6.0",
     "rimraf": "3.0.2",
-    "semantic-release": "17.0.4",
-    "ts-jest": "25.3.1",
+    "semantic-release": "17.0.6",
+    "ts-jest": "25.4.0",
     "tslint": "6.1.1",
     "tslint-config-airbnb": "5.11.2",
     "typescript": "3.8.3"

--- a/src/response.ts
+++ b/src/response.ts
@@ -68,7 +68,15 @@ export class Response {
     });
     this.links = jest.fn(() => this);
     this.location = jest.fn(() => this);
-    this.redirect = jest.fn();
+    this.redirect = jest.fn((status : number, url : string) => {
+      if (url) {
+        this.statusCode = status;
+        this.setHeader('Location', url);
+      } else {
+        this.statusCode = 307;
+        this.setHeader('Location', status);
+      }
+    });
     this.render = jest.fn();
     this.send = jest.fn((data: any) => {
       this.body = data;

--- a/test/unit/response.test.ts
+++ b/test/unit/response.test.ts
@@ -556,6 +556,18 @@ describe('Express Response', () => {
 
       expect(response.redirect).toHaveBeenCalled();
       expect(response.redirect).toHaveBeenCalledWith(value);
+      expect(response.getHeader('Location')).toEqual(value);
+    });
+
+    test('something', () => {
+      const value = chance.string();
+      const statusCode = 307;
+      response.redirect(statusCode, value);
+
+      expect(response.redirect).toHaveBeenCalled();
+      expect(response.redirect).toHaveBeenCalledWith(statusCode, value);
+      expect(response.statusCode).toEqual(307);
+      expect(response.getHeader('Location')).toEqual(value);
     });
 
     test('redirect should have no call after reset', () => {


### PR DESCRIPTION
**What**:
- support for [`response.redirect()`](https://expressjs.com/en/api.html#res.redirect)
- updating node modules

**Why**:
- test behavior of redirect

**How**:
- reflect redirect in the response `Location` header